### PR TITLE
Use the version of ios-sim on the path if it exists

### DIFF
--- a/lib/sim_launcher/simulator.rb
+++ b/lib/sim_launcher/simulator.rb
@@ -44,6 +44,12 @@ class Simulator
   end
   
   def iphonesim_path(version)
+    installed = `which ios-sim`
+    if installed =~ /(.*ios-sim)/
+      puts "Using installed ios-sim at #{$1}"
+      return $1
+    end
+
     File.join( File.dirname(__FILE__), '..', '..', 'native', 'ios-sim' )
   end
 end


### PR DESCRIPTION
The checked in binary does not work with the newest version of Xcode. 

sh: line 1: 19468 Trace/BPT trap: 5       /Users/chris/.rvm/gems/ruby-1.9.2-p320@Cali/gems/sim_launcher-0.4.0/lib/sim_launcher/../../native/ios-sim "showsdks" 2>&1
sh: line 1: 19472 Trace/BPT trap: 5       /Users/chris/.rvm/gems/ruby-1.9.2-p320@Cali/gems/sim_launcher-0.4.0/lib/sim_launcher/../../native/ios-sim "launch" "/Users/chris/Library/Developer/Xcode/DerivedData/bandOfTheDay-diyzomxmpebzxyfialpfhqgywqwy/Build/Products/Debug-iphonesimulator/bandOfTheDayFrank.app" "--sdk" "" "--family" "iphone" "--exit" 2>&1

I've added a check to see if there is a version of ios-sim on the $PATH. We use brew to install ios-sim and check that it works. Any better ideas?
