### PR TITLE
Fix intermittent failures invoking SimLauncher::Simulator::xcode_version

### DIFF
--- a/lib/sim_launcher/simulator.rb
+++ b/lib/sim_launcher/simulator.rb
@@ -3,7 +3,7 @@ module SimLauncher
 class Simulator
 
   def initialize( iphonesim_path_external = nil )
-    @iphonesim_path = iphonesim_path_external || iphonesim_path(xcode_version)
+    @iphonesim_path = iphonesim_path_external || iphonesim_path
   end
 
   def showsdks
@@ -90,12 +90,15 @@ class Simulator
   end
   
   def xcode_version
-    version = `xcodebuild -version`
-    raise "xcodebuild not found" unless $? == 0
-    version[/([0-9]\.[0-9])/, 1].to_f
+    version_out = `xcodebuild -version`
+    begin
+      Float(version_out[/([0-9]\.[0-9])/, 1])
+    rescue => ex
+      raise "Cannot determine xcode version: #{ex}"
+    end
   end
   
-  def iphonesim_path(version)
+  def iphonesim_path
     installed = `which ios-sim`
     if installed =~ /(.*ios-sim)/
       puts "Using installed ios-sim at #{$1}"

--- a/lib/sim_launcher/version.rb
+++ b/lib/sim_launcher/version.rb
@@ -1,3 +1,3 @@
 module SimLauncher
-  VERSION = "0.4.9"
+  VERSION = "0.4.9.mdsol"
 end


### PR DESCRIPTION
Using Xcode 5.0.2 on OS X 10.9, `xcodebuild -version` will intermittently have a non-zero exit on success.

Example of non-zero exits:

``` ruby
run_num = 0
last_exit = 0
until last_exit != 0 do
    run_num += 1
    `xcodebuild -version`
    last_exit = $?
end
puts "Got non-zero exit after #{run_num} runs"
```

Output (above saved as 'txc.rb'):

```
cranky:tmp jtomson$ ruby txc.rb 
Got non-zero exit after 8 runs
cranky:tmp jtomson$ ruby txc.rb 
Got non-zero exit after 181 runs
cranky:tmp jtomson$ ruby txc.rb 
Got non-zero exit after 421 runs
cranky:tmp jtomson$ ruby txc.rb 
```

When this non-zero exit occurs, Frank-Cucumber Scenarios will fail.

This change will detect `xcodebuild` invocation failure via parsing exceptions instead of exit code for `Simulator::xcode_version`, and clean up its usage (currently its result passed to `iphonesim_path` is unused)
