### PR TITLE
Defaulted sim launch to --retina and --tall

### DIFF
--- a/lib/sim_launcher/simulator.rb
+++ b/lib/sim_launcher/simulator.rb
@@ -52,7 +52,7 @@ class Simulator
     end
     sdk_version ||= SdkDetector.new(self).latest_sdk_version
     args = ["--args"] + app_args.flatten if app_args
-    run_synchronous_command( :launch, app_path, '--sdk', sdk_version, '--family', device_family, '--exit', *args )
+    run_synchronous_command( :launch, app_path, '--sdk', sdk_version, '--family', device_family, '--retina', '--tall', '--exit', *args )
   end
 
   def launch_ipad_app( app_path, sdk )


### PR DESCRIPTION
Hi there, this pr defaults launching the sim to make use of --retina and --tall. Without these options, the sim will always come up in 3.5-inch mode. As the iPhone4 os almost a distant memory now for for iOS devices, it strikes me that defaulting to retina tall (ie 4-inch) is the right way to go. Hope this helps, happy to make any improvements or changes necessary if you think there's a better way to solve this problem.
