### PR TITLE
iphone_simpath should only print "Using ios-sim at..." message when debugging

### DIFF
--- a/lib/sim_launcher/simulator.rb
+++ b/lib/sim_launcher/simulator.rb
@@ -109,7 +109,7 @@ class Simulator
 
     installed = `which #{binary_name}`
     if installed =~ /(.*ios-sim)/
-      puts "Using installed #{binary_name} at #{$1}"
+      puts "Using installed #{binary_name} at #{$1}" if $DEBUG
       return $1
     end
 


### PR DESCRIPTION
Limits the puts statement with $DEBUG

Calabash iOS calls Simulator.new often and each time this message is generated.  

Let me know if you want something fancier.
