### PR TITLE
xcode-select should use --print-path flag

### DIFF
--- a/lib/sim_launcher/simulator.rb
+++ b/lib/sim_launcher/simulator.rb
@@ -101,7 +101,7 @@ class Simulator
   def iphonesim_path
     binary_name = 'ios-sim'
 
-    framework_dir = `xcode-select -p`.chomp + 'Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/iPhoneSimulatorRemoteClient.framework'
+    framework_dir = `xcode-select --print-path`.chomp + 'Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/iPhoneSimulatorRemoteClient.framework'
 
     if File.directory?(framework_dir)
       binary_name = 'ios-sim-old'


### PR DESCRIPTION
## motivation

Calabash users are reporting:

```
xcode-select: Error: unknown command option '-p'.
```

I cannot reproduce locally, but it has been reported multiple times.

I have not been able to pin this to a particular version of MacOS, command-line tools, or Xcode.

I am stumped.

I did a grep over ios-sim and calabash for `xcode-select -p` and I believe that sim_launcher is the only place `-p` is used.
